### PR TITLE
The Verification Update

### DIFF
--- a/inno.iss
+++ b/inno.iss
@@ -41,6 +41,7 @@ DisableDirPage=auto
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 DirExistsWarning=no
+MinVersion=6.2.9200
 
 [Files]
 Source: "{#MainJarFile}"; DestDir: "{app}"; Flags: ignoreversion

--- a/inno.iss
+++ b/inno.iss
@@ -261,6 +261,10 @@ Filename: "{tmp}\7za.exe"; Parameters: "x -y {tmp}\jre.zip"; WorkingDir: "{app}"
 Filename: "{app}\jre\bin\javaw.exe"; Parameters: "-Xmx512M -jar ""{app}\{#MainJarFile}"""; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent
 
 [UninstallDelete]
+; Installer files
 Type: filesandordirs; Name: "{app}\jre"
 Type: filesandordirs; Name: "{userappdata}\.minecraft\{#AppDir}"
 Type: filesandordirs; Name: "{userappdata}\.minecraft\{#AppDir}\javafx"
+; Installer + Launcher files
+Type: filesandordirs; Name: "{userappdata}\.minecraft\launcher_profiles.json.skbak"
+Type: filesandordirs; Name: "{userappdata}\.minecraft\sklauncher-fx.jar"

--- a/inno.iss
+++ b/inno.iss
@@ -128,6 +128,14 @@ end;
 
 procedure RenameJRE;
 begin
+  if DirExists(ExpandConstant('{app}\\jre')) then begin
+    Log('Deleting old jre directory');
+    if not DelTree(ExpandConstant('{app}\\jre'), True, True, True) then begin
+      Log('Failed to delete old jre folder');
+      Exit;
+    end;
+  end;
+
   Log('Renaming jre directory');
   if not RenameFile(ExpandConstant('{app}\\{#JREFolder}'), ExpandConstant('{app}\\jre')) then begin
     Log('Failed to rename jre folder');


### PR DESCRIPTION
I don't even know what this PR is going to end up being, especially if going from Batch to Pascal involves quintuple reading. 😛


# Commit explanation

> Allow installation only on Windows 8 and higher

Since in Windows 7, when it tries to download Java / JavaFX, it will get the error `Server Certificate Invalid or not present` and it's not something you plan to fix...it's better not to start the installation in the first place.

But I actually tested it on Windows 8.1, I choose to believe it will work on Windows 8. xD

**A "hey, you're on an obsolete OS, things might not work" warning could be created.**

> Delete jre folder before renaming the new one
> Since the user might want to update/reinstall

I don't think I need to explain anything here.

> Also delete some launcher files when uninstalling

The main reason why I want to change the installer. :'v

**It would be great to be able to ask the user if he wants to remove...
\- Installer files
\- Installer and Launcher files
\- Installer, Launcher and Game files (everything)**

***

# List of potential changes
- [ ] Alert message if OS is obsolete
- [ ] Allow selecting how many things to uninstall
- [ ] Change style and reorder code

```iss
; Example of changing to a vertical style
; Remember that ";" is a comment outside the [Code] section and "{}" / "{**}" / "//" is a comment inside that section.
[Setup]
AppId =         {{A151427E-7A46-4D6D-8534-C4C04BADA77A}
AppName =       {#AppName} {#AppVersionShort}
AppVersion =    {#AppVersion}

[Icons]
Name: "{group}\{#AppName}";             Filename: "{app}\jre\bin\javaw.exe"; Parameters: "-Xmx512M -jar ""{app}\{#MainJarFile}""";  IconFilename: "{app}\icon.ico"; WorkingDir: "{app}"
Name: "{userdesktop}\{#AppName}";       Filename: "{app}\jre\bin\javaw.exe"; Parameters: "-Xmx512M -jar ""{app}\{#MainJarFile}""";  IconFilename: "{app}\icon.ico"; WorkingDir: "{app}"
Name: "{group}\Uninstall {#AppName}";   Filename: "{uninstallexe}";                                                                 IconFilename: "{app}\icon.ico"

; JavaDocs equivalent :v
[Code]
{**
 * Triggered when the user clicks the "Next" button during setup.
 * If on the "Ready to Install" page, begins downloading required JRE and JavaFX components.
 * Handles errors or user cancellations gracefully.
 *
 * @param CurPageID - The ID of the current wizard page.
 * @return True if allowed to proceed, False if installation should stop.
 *}
function NextButtonClick(CurPageID: Integer): Boolean;
    // Blablabla...
```

- [ ] If the user downloaded everything needed in the same folder as the installer, use that instead of downloading it.
- [ ] Remove Herobrine